### PR TITLE
Some minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,10 +71,7 @@ module.exports = {
             // set the bucket file url
             file.url = data.Location;
 
-            resolve({
-							url: file.url,
-							data: data
-						});
+            resolve({ url: file.url, 'data': data });
           });
         });
       },
@@ -92,7 +89,7 @@ module.exports = {
               return reject(err);
             }
 
-            resolve({data: data});
+            resolve({'data': data});
           });
         });
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,16 +34,16 @@ module.exports = {
       type: 'text'
     }
   },
-  init: (config) => {
+  init: (config,endpoint='nyc3.digitaloceanspaces.com',region='NYC3') => {
 
-    const spacesEndpoint = new AWS.Endpoint('nyc3.digitaloceanspaces.com');
+    const spacesEndpoint = new AWS.Endpoint(endpoint);
 
     // configure AWS DO bucket connection
     AWS.config.update({
       endpoint: spacesEndpoint,
       accessKeyId: config.public,
       secretAccessKey: config.private,
-      region: 'NYC3'
+      region: region
     });
 
 
@@ -56,26 +56,29 @@ module.exports = {
     });
 
     return {
-      upload: (file) => {
+      upload: async (file,acl='public-read',file_type='binary') => {
         return new Promise((resolve, reject) => {
           // upload file on DO bucket
           DO.upload({
             Key: `${file.hash}${file.ext}`,
-            Body: new Buffer(file.buffer, 'binary'),
-            ACL: 'public-read'
+            Body: new Buffer(file.buffer, file_type),
+            ACL: acl
           }, (err, data) => {
             if (err) {
-              return reject(err);
+              return reject(err,data);
             }
 
             // set the bucket file url
             file.url = data.Location;
 
-            resolve();
+            resolve({
+							url: file.url,
+							data: data
+						});
           });
         });
       },
-      delete: (file) => {
+      delete: async (file) => {
         return new Promise((resolve, reject) => {
           // delete file on DO bucket
           DO.deleteObjects({
@@ -89,7 +92,7 @@ module.exports = {
               return reject(err);
             }
 
-            resolve();
+            resolve({data: data});
           });
         });
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "bundleDependencies": false,
   "dependencies": {
-    "aws-sdk": "^2.199.0"
+    "aws-sdk": "^2.199.0",
+    "lodash": "^4.17.10"
   },
   "deprecated": false,
   "description": "DigitalOcean provider for strapi upload",


### PR DESCRIPTION
So a few things were added to make the API a bit more flexible. I found that hardcoding things like NYC3 and the endpoints to S3 could have atleast been extra params with default values. 

lodash wasn't included in the package.json, so I did a "npm -s install lodash". Added a .gitignore. 

The "async" keywords I added to your closures are not only syntactic sugar, but they also tell the calling function that it should expect a promise to be returned. It's not required, but it self-documents the function's behaviour. 

I hope this helps you out. Please note, I don't have S3 or DO access so I haven't tested this code. The changes I made won't break existing code that calls this library.